### PR TITLE
0.0.8 core breaking

### DIFF
--- a/packages/cleanly_architected_core/CHANGELOG.md
+++ b/packages/cleanly_architected_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.8] - 17 December 2020
+- Fix ci failed caused by dartfmt.
+- (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name.
+
 ## [0.0.7] - 17 December 2020
 - (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name.
 

--- a/packages/cleanly_architected_core/CHANGELOG.md
+++ b/packages/cleanly_architected_core/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [0.0.8] - 17 December 2020
+- Sorry! I released too hasty (0.0.7) and confidently without PR and waiting CI to complete.
 - Fix ci failed caused by dartfmt.
 - (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name.
 

--- a/packages/cleanly_architected_core/lib/src/data_source/local_data_source.dart
+++ b/packages/cleanly_architected_core/lib/src/data_source/local_data_source.dart
@@ -55,8 +55,10 @@ abstract class LocalDataSource<T extends EquatableEntity,
       return;
     }
 
-    final filteredData =
-        data.where((e) => e.entityIdentifier != null && e.entityIdentifier.isNotEmpty).toList();
+    final filteredData = data
+        .where(
+            (e) => e.entityIdentifier != null && e.entityIdentifier.isNotEmpty)
+        .toList();
 
     final Map<String, Map<String, dynamic>> reducedData = filteredData
         .fold<Map<String, Map<String, dynamic>>>(

--- a/packages/cleanly_architected_core/pubspec.yaml
+++ b/packages/cleanly_architected_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_core
 description: A dart project to help set up clean architecture with less boilerplate.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_core
 
 environment:

--- a/packages/cleanly_architected_core/test/data_source/local_query_data_source_test.dart
+++ b/packages/cleanly_architected_core/test/data_source/local_query_data_source_test.dart
@@ -70,7 +70,7 @@ void main() {
   });
 
   group('putAll', () {
-    group('should not do anything if ', () {
+    group('should not do anything if', () {
       test('storageName null', () async {
         final dataSource2 =
             _TestEntityLocalQueryDataSource2(storage: mockStorage);
@@ -90,13 +90,31 @@ void main() {
       });
     });
 
-    test('should exclude data which id returns null', () async {
+    test('should exclude data which entityIdentifier == null', () async {
       final fixtures = [
         _TestEntity(id: null, name: 'Apple'),
         _TestEntity(id: '2', name: 'Orange'),
         _TestEntity(id: null, name: 'Grape'),
         _TestEntity(id: '4', name: 'Pineapple'),
         _TestEntity(id: null, name: 'Banana'),
+      ];
+
+      await dataSource.putAll(data: fixtures);
+
+      verify(mockStorage.putAll(storageName: 'test-storage', data: {
+        '2': {'id': '2', 'name': 'Orange'},
+        '4': {'id': '4', 'name': 'Pineapple'}
+      }));
+    });
+
+    test('should exclude data which entityIdentifier == empty string',
+        () async {
+      final fixtures = [
+        _TestEntity(id: '', name: 'Apple'),
+        _TestEntity(id: '2', name: 'Orange'),
+        _TestEntity(id: '', name: 'Grape'),
+        _TestEntity(id: '4', name: 'Pineapple'),
+        _TestEntity(id: '', name: 'Banana'),
       ];
 
       await dataSource.putAll(data: fixtures);


### PR DESCRIPTION
cleanly_architected_core

## [0.0.8] - 17 December 2020
- Sorry! I released too hasty (0.0.7) and confidently without PR and waiting CI to complete.
- Fix ci failed caused by dartfmt.
- (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name.