### PR TITLE
0.0.4 cleanly bloc

### DIFF
--- a/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
+++ b/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.4] - 17 December 2020
+- (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name. _(Copied from cleanly_architected_core 0.0.8 changelog)_
+
 ## [0.0.3] - 14 December 2020
 - Make readme file better
 

--- a/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
+++ b/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_state_manager_bloc
 description: State manager for cleanly architected using bloc / cubit. This way, you can use the core with other state manager as well. 
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_state_manager_bloc
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   bloc: ^6.1.1
-  cleanly_architected_core: ^0.0.5
+  cleanly_architected_core: ^0.0.8
   dartz: ^0.9.1
   equatable: ^1.2.5
   meta: ^1.2.4

--- a/packages/cleanly_architected_state_manager_bloc/test/deletion_cubit_test.dart
+++ b/packages/cleanly_architected_state_manager_bloc/test/deletion_cubit_test.dart
@@ -6,7 +6,8 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 class _TestEntity extends EquatableEntity {
-  _TestEntity(String id) : super(id);
+  final String id;
+  _TestEntity(this.id);
 
   @override
   List<Object> get props => [id];
@@ -15,6 +16,9 @@ class _TestEntity extends EquatableEntity {
   Map<String, dynamic> toJson() {
     throw UnimplementedError();
   }
+
+  @override
+  String get entityIdentifier => id;
 }
 
 // ignore: must_be_immutable

--- a/packages/cleanly_architected_state_manager_bloc/test/form_cubit_test.dart
+++ b/packages/cleanly_architected_state_manager_bloc/test/form_cubit_test.dart
@@ -6,7 +6,8 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 class _TestEntity extends EquatableEntity {
-  _TestEntity(String id) : super(id);
+  final String id;
+  _TestEntity(this.id);
 
   @override
   List<Object> get props => [id];
@@ -15,6 +16,9 @@ class _TestEntity extends EquatableEntity {
   Map<String, dynamic> toJson() {
     throw UnimplementedError();
   }
+
+  @override
+  String get entityIdentifier => id;
 }
 
 // ignore: must_be_immutable

--- a/packages/cleanly_architected_state_manager_bloc/test/query_cubit_test.dart
+++ b/packages/cleanly_architected_state_manager_bloc/test/query_cubit_test.dart
@@ -6,7 +6,8 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 class _TestEntity extends EquatableEntity {
-  _TestEntity(String id) : super(id);
+  final String id;
+  _TestEntity(this.id);
 
   @override
   List<Object> get props => [id];
@@ -15,6 +16,9 @@ class _TestEntity extends EquatableEntity {
   Map<String, dynamic> toJson() {
     throw UnimplementedError();
   }
+
+  @override
+  String get entityIdentifier => id;
 }
 
 // ignore: must_be_immutable


### PR DESCRIPTION
## [0.0.4] - 17 December 2020
- (BREAKING!) `EquatableEntity` no longer requires id, instead, it now requires you to override a getter called `entityIdentifier`. This is the new way to get unique field from your entity. This way, you can have your own `id`. I named it `entityIdentifier` for less chance to conflict with your own field name. _(Copied from cleanly_architected_core 0.0.8 changelog)_