### PR TITLE
Update core to 0.0.12

### DIFF
--- a/packages/cleanly_architected_core/CHANGELOG.md
+++ b/packages/cleanly_architected_core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.12] - 28 December 2020
+- (BUG) `DataRepository`'s `refreshAll` should clear existing `cachedData` instead of just appending it. `readNext` behavior stays the same
+
 ## [0.0.11] - 18 December 2020
 Removed both `GraphQLParams` and `CleanApiClient`. After further consideration. I think this put unecessary restriction on the implementation without much to gain. I will still keep `CleanLocalStorage`, because it will make some functions in `LocalFormCacheDataSource` and `LocalDataSource` doesn't need to be keep re-implemented each time.
 

--- a/packages/cleanly_architected_core/lib/src/repository/data_repository.dart
+++ b/packages/cleanly_architected_core/lib/src/repository/data_repository.dart
@@ -113,7 +113,10 @@ class DataRepository<T extends EquatableEntity, U extends QueryParams<T>> {
       }
 
       if (remoteQueryDataSource == null) {
-        await _queryLocally(pageSize: pageSize, params: params);
+        await _queryLocally(
+          pageSize: pageSize,
+          params: params,
+        );
         endOfList = true;
         return Right(cachedData.take(pageSize).toList());
       }
@@ -122,6 +125,7 @@ class DataRepository<T extends EquatableEntity, U extends QueryParams<T>> {
         pageNumber: 1,
         pageSize: pageSize,
         params: params,
+        clearCached: true,
       );
 
       return Right(cachedData.take(pageSize).toList());
@@ -201,6 +205,7 @@ class DataRepository<T extends EquatableEntity, U extends QueryParams<T>> {
     @required int pageSize,
     @required int pageNumber,
     @required U params,
+    bool clearCached = false,
   }) async {
     if (remoteQueryDataSource == null) {
       endOfList = true;
@@ -213,7 +218,11 @@ class DataRepository<T extends EquatableEntity, U extends QueryParams<T>> {
       params: params,
     );
 
-    cachedData = [...cachedData, ...remoteResults];
+    if (!clearCached) {
+      cachedData = [...cachedData, ...remoteResults];
+    } else {
+      cachedData = [...remoteResults];
+    }
     final ids = cachedData.map((e) => e.entityIdentifier).toSet();
     cachedData.retainWhere((x) => ids.remove(x.entityIdentifier));
 

--- a/packages/cleanly_architected_core/pubspec.yaml
+++ b/packages/cleanly_architected_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_core
 description: A dart project to help set up clean architecture with less boilerplate.
-version: 0.0.11
+version: 0.0.12
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_core
 
 environment:

--- a/packages/cleanly_architected_core/test/repository/data_repository_test.dart
+++ b/packages/cleanly_architected_core/test/repository/data_repository_test.dart
@@ -514,7 +514,7 @@ void main() {
       verifyZeroInteractions(mockRemoteDataSource);
     });
 
-    group('will call remoteDataSource', () {
+    group('will call remoteDataSource and replace existing cachedData', () {
       Future<void> _performTest() async {
         when(mockRemoteDataSource.read(
           pageNumber: anyNamed('pageNumber'),
@@ -527,6 +527,10 @@ void main() {
             _TestEntity('3', 'Pineapple'),
           ],
         );
+
+        repo.cachedData = [
+          _TestEntity('XYZ', 'Any fruit'),
+        ];
 
         final results = await repo.refreshAll(
           pageSize: 3,

--- a/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
+++ b/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.8] - 28 December 2020
+- Set minimum supported `cleanly_architected_core` to `0.0.12`. Read the changelog [here](https://github.com/moseskarunia/cleanly-architected/blob/master/packages/cleanly_architected_core/CHANGELOG.md)
+
 ## [0.0.7] - 18 December 2020
 - Set minimum supported `cleanly_architected_core` to `0.0.11`. Read the changelog [here](https://github.com/moseskarunia/cleanly-architected/blob/master/packages/cleanly_architected_core/CHANGELOG.md)
 

--- a/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
+++ b/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_state_manager_bloc
 description: State manager for cleanly architected using bloc / cubit. This way, you can use the core with other state manager as well.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_state_manager_bloc
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   bloc: ^6.1.1
-  cleanly_architected_core: ^0.0.11
+  cleanly_architected_core: ^0.0.12
   dartz: ^0.9.1
   equatable: ^1.2.5
   meta: ^1.2.4


### PR DESCRIPTION
## [0.0.12] - 28 December 2020
- (BUG) `DataRepository`'s `refreshAll` should clear existing `cachedData` instead of just appending it. `readNext` behavior stays the same