### PR TITLE
Core 0.0.13

### DIFF
--- a/packages/cleanly_architected_core/CHANGELOG.md
+++ b/packages/cleanly_architected_core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.13] - 29 December 2020
+- (BUG) In `DataRepository`'s `delete`, if querying localDataSource after deleting, the return value should replace cachedData instead of just appending.
+
 ## [0.0.12] - 28 December 2020
 - (BUG) `DataRepository`'s `refreshAll` should clear existing `cachedData` instead of just appending it. `readNext` behavior stays the same
 

--- a/packages/cleanly_architected_core/lib/src/repository/data_repository.dart
+++ b/packages/cleanly_architected_core/lib/src/repository/data_repository.dart
@@ -151,7 +151,7 @@ class DataRepository<T extends EquatableEntity, U extends QueryParams<T>> {
 
       if (lastParams != null) {
         final localResults = await localDataSource.read(params: lastParams);
-        cachedData = [...localResults];
+        cachedData = localResults;
       }
 
       return Right(unit);

--- a/packages/cleanly_architected_core/pubspec.yaml
+++ b/packages/cleanly_architected_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_core
 description: A dart project to help set up clean architecture with less boilerplate.
-version: 0.0.12
+version: 0.0.13
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_core
 
 environment:

--- a/packages/cleanly_architected_core/test/repository/data_repository_test.dart
+++ b/packages/cleanly_architected_core/test/repository/data_repository_test.dart
@@ -640,11 +640,12 @@ void main() {
               (_) async => [
                 _TestEntity('1', 'Orange'),
                 _TestEntity('2', 'Strawberry'),
-                _TestEntity('3', 'Pineapple'),
               ],
             );
             repo.cachedData = [
               _TestEntity('1', 'Orange'),
+              _TestEntity('2', 'Strawberry'),
+              _TestEntity('3', 'Pineapple'),
             ];
             repo.lastParams = _TestEntityQueryParams('abc');
             await repo.deleteLocalData(id: '3');
@@ -655,7 +656,6 @@ void main() {
             expect(repo.cachedData, [
               _TestEntity('1', 'Orange'),
               _TestEntity('2', 'Strawberry'),
-              _TestEntity('3', 'Pineapple'),
             ]);
             verifyZeroInteractions(mockRemoteDataSource);
           });

--- a/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
+++ b/packages/cleanly_architected_state_manager_bloc/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.9] - 28 December 2020
+- Set minimum supported `cleanly_architected_core` to `0.0.13`. Read the changelog [here](https://github.com/moseskarunia/cleanly-architected/blob/master/packages/cleanly_architected_core/CHANGELOG.md)
+
 ## [0.0.8] - 28 December 2020
 - Set minimum supported `cleanly_architected_core` to `0.0.12`. Read the changelog [here](https://github.com/moseskarunia/cleanly-architected/blob/master/packages/cleanly_architected_core/CHANGELOG.md)
 

--- a/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
+++ b/packages/cleanly_architected_state_manager_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cleanly_architected_state_manager_bloc
 description: State manager for cleanly architected using bloc / cubit. This way, you can use the core with other state manager as well.
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/moseskarunia/cleanly-architected/tree/master/packages/cleanly_architected_state_manager_bloc
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   bloc: ^6.1.1
-  cleanly_architected_core: ^0.0.12
+  cleanly_architected_core: ^0.0.13
   dartz: ^0.9.1
   equatable: ^1.2.5
   meta: ^1.2.4


### PR DESCRIPTION
- (BUG) In `DataRepository`'s `delete`, if querying localDataSource after deleting, the return value should replace cachedData instead of just appending.